### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/paulbasha/160f8b45-c27e-4c1b-bd66-5e27022612ed/20f1b440-39f6-4893-a510-2946c21be3ca/_apis/work/boardbadge/ca6f3113-0a70-4e27-a7e5-b7080df8ef90)](https://dev.azure.com/paulbasha/160f8b45-c27e-4c1b-bd66-5e27022612ed/_boards/board/t/20f1b440-39f6-4893-a510-2946c21be3ca/Microsoft.RequirementCategory)
 # azuretpoc


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#20](https://dev.azure.com/paulbasha/160f8b45-c27e-4c1b-bd66-5e27022612ed/_workitems/edit/20). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.